### PR TITLE
Add unit tests for AuthServiceImpl, JwtServiceImpl, AuthUseCase, and …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.6</version>

--- a/src/test/java/com/gtu/auth_service/application/service/AuthServiceImplTest.java
+++ b/src/test/java/com/gtu/auth_service/application/service/AuthServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.gtu.auth_service.application.service;
+
+import com.gtu.auth_service.domain.model.AuthUser;
+import com.gtu.auth_service.domain.model.Role;
+import com.gtu.auth_service.infrastructure.client.PassengerClient;
+import com.gtu.auth_service.infrastructure.client.UserClient;
+import com.gtu.auth_service.infrastructure.client.dto.UserServiceResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+class AuthServiceImplTest {
+    @Mock
+    private UserClient userClient;
+
+    @Mock
+    private PassengerClient passengerClient;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void findUserByEmail_WhenUserExists_ShouldReturnAuthUser() {
+        UserServiceResponse userResponse = new UserServiceResponse(1L, "John Doe", "jhon.doe@example.com", "encodedPass", "DRIVER");
+        when(userClient.getUserByEmail("jhon.doe@example.com")).thenReturn(userResponse);
+
+        AuthUser result = authService.findUserByEmail("jhon.doe@example.com");
+
+        assertEquals(1L, result.id());
+        assertEquals("John Doe", result.name());
+        assertEquals("jhon.doe@example.com", result.email());
+        assertEquals("encodedPass", result.password());
+        assertEquals(Role.DRIVER, result.role());
+    }
+
+    @Test
+    void findUserByEmail_WhenNoUserOrPassengerExists_ShouldReturnNull() {
+        when(userClient.getUserByEmail("nonexistent@example.com")).thenReturn(null);
+        when(passengerClient.getPassengerByEmail("nonexistent@example.com")).thenReturn(null);
+
+        AuthUser result = authService.findUserByEmail("nonexistent@example.com");
+
+        assertNull(result);
+    }
+
+    @Test
+    void mapToRole_WhenValidRole_ShouldMapCorrectly() {
+        assertEquals(Role.SUPERADMIN, authService.mapToRole("SUPERADMIN"));
+        assertEquals(Role.ADMIN, authService.mapToRole("ADMIN"));
+        assertEquals(Role.DRIVER, authService.mapToRole("DRIVER"));
+    }
+
+    @Test
+    void mapToRole_WhenNullRole_ShouldThrowIllegalArgumentException() {
+        try {
+            authService.mapToRole(null);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Role cannot be null", e.getMessage());
+        }
+    }
+
+    @Test
+    void mapToRole_WhenInvalidRole_ShouldThrowIllegalArgumentException() {
+        try {
+            authService.mapToRole("INVALID");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid role: INVALID", e.getMessage());
+        }
+    } 
+}

--- a/src/test/java/com/gtu/auth_service/application/service/JwtServiceImplTest.java
+++ b/src/test/java/com/gtu/auth_service/application/service/JwtServiceImplTest.java
@@ -1,0 +1,46 @@
+package com.gtu.auth_service.application.service;
+
+import com.gtu.auth_service.domain.model.AuthUser;
+import com.gtu.auth_service.domain.model.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+import java.lang.reflect.Field;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtServiceImplTest {
+    @InjectMocks
+    private JwtServiceImpl jwtService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jwtService = new JwtServiceImpl();
+
+        String rawKey = "testSecretKeyForJWTtestSecretKeyForJWT"; 
+        String base64Key = Base64.getEncoder().encodeToString(rawKey.getBytes());
+
+        Field field = JwtServiceImpl.class.getDeclaredField("secretKey");
+        field.setAccessible(true);
+        field.set(jwtService, base64Key);
+    }
+
+    @Test
+    void generateToken_WhenUserProvided_ShouldReturnNonNullToken() {
+        AuthUser user = new AuthUser(1L, "John Doe", "john.doe@example.com", "password", Role.DRIVER);
+        String token = jwtService.generateToken(user);
+
+        assertNotNull(token);
+        assertTrue(token.length() > 0);
+    }
+
+    @Test
+    void getExpirationTime_ShouldReturn30Minutes() {
+        long expiration = jwtService.getExpirationTime();
+        assertEquals(30L * 60000, expiration); // 30 minutes in milliseconds
+    }
+}

--- a/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
+++ b/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
@@ -1,0 +1,76 @@
+package com.gtu.auth_service.application.usecase;
+
+import com.gtu.auth_service.application.dto.LoginRequestDTO;
+import com.gtu.auth_service.application.dto.LoginResponseDTO;
+import com.gtu.auth_service.application.service.AuthServiceImpl;
+import com.gtu.auth_service.application.service.JwtServiceImpl;
+import com.gtu.auth_service.domain.model.AuthUser;
+import com.gtu.auth_service.domain.model.Role;
+import com.gtu.auth_service.infrastructure.security.PasswordValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class AuthUseCaseTest {
+    @Mock
+    private AuthServiceImpl authService;
+
+    @Mock
+    private JwtServiceImpl jwtService;
+
+    @Mock
+    private PasswordValidator passwordValidator;
+
+    @InjectMocks
+    private AuthUseCase authUseCase;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void login_WhenValidCredentials_ShouldReturnLoginResponse() {
+        LoginRequestDTO request = new LoginRequestDTO("john.doe@example.com", "password123");
+        AuthUser user = new AuthUser(1L, "John Doe", "john.doe@example.com", "encodedPass", Role.DRIVER);
+        String token = "mocked-jwt-token";
+
+        when(authService.findUserByEmail("john.doe@example.com")).thenReturn(user);
+        when(passwordValidator.validate("password123", "encodedPass")).thenReturn(true);
+        when(jwtService.generateToken(user)).thenReturn(token);
+
+        LoginResponseDTO response = authUseCase.login(request);
+
+        assertEquals(token, response.accessToken());
+        assertEquals(1L, response.userId());
+        assertEquals("John Doe", response.name());
+        assertEquals("john.doe@example.com", response.email());
+        assertEquals("DRIVER", response.role());
+    }
+
+    @Test
+    void login_WhenUserNotFound_ShouldThrowIllegalArgumentException() {
+        LoginRequestDTO request = new LoginRequestDTO("nonexistent@example.com", "password123");
+
+        when(authService.findUserByEmail("nonexistent@example.com")).thenReturn(null);
+
+        assertThrows(IllegalArgumentException.class, () -> authUseCase.login(request));
+    }
+
+    @Test
+    void login_WhenInvalidPassword_ShouldThrowIllegalArgumentException() {
+        LoginRequestDTO request = new LoginRequestDTO("john.doe@example.com", "wrongpass");
+        AuthUser user = new AuthUser(1L, "John Doe", "john.doe@example.com", "encodedPass", Role.DRIVER);
+
+        when(authService.findUserByEmail("john.doe@example.com")).thenReturn(user);
+        when(passwordValidator.validate("wrongpass", "encodedPass")).thenReturn(false);
+
+        assertThrows(IllegalArgumentException.class, () -> authUseCase.login(request));
+    }
+}

--- a/src/test/java/com/gtu/auth_service/infrastructure/security/PasswordValidatorTest.java
+++ b/src/test/java/com/gtu/auth_service/infrastructure/security/PasswordValidatorTest.java
@@ -1,0 +1,44 @@
+package com.gtu.auth_service.infrastructure.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PasswordValidatorTest {
+    @InjectMocks
+    private PasswordValidator passwordValidator;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void validate_WhenPasswordMatches_ShouldReturnTrue() {
+        String rawPassword = "password123";
+        String encodedPassword = new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder().encode(rawPassword);
+
+        assertTrue(passwordValidator.validate(rawPassword, encodedPassword));
+    }
+
+    @Test
+    void validate_WhenPasswordDoesNotMatch_ShouldReturnFalse() {
+        String rawPassword = "password123";
+        String wrongEncodedPassword = new BCryptPasswordEncoder().encode("wrongpass");
+
+        assertFalse(passwordValidator.validate(rawPassword, wrongEncodedPassword));
+    }
+
+    @Test
+    void validate_WhenExceptionOccurs_ShouldReturnFalse() {
+        String rawPassword = null; 
+        String encodedPassword = "invalidEncoded";
+
+        assertFalse(passwordValidator.validate(rawPassword, encodedPassword));
+    }
+}


### PR DESCRIPTION
This pull request introduces unit tests for various components in the authentication service and adds necessary testing dependencies to the project. The changes aim to improve test coverage and ensure the reliability of key functionalities such as user authentication, JWT token generation, and password validation.

### Dependencies added for testing:
* Added `mockito-core`, `junit-jupiter-api`, and `junit-jupiter-engine` dependencies to `pom.xml` to enable mocking and unit testing.

### Unit tests for service components:
* **AuthServiceImpl**: Added tests to verify user retrieval by email, role mapping, and handling of invalid roles.
* **JwtServiceImpl**: Added tests to validate JWT token generation and expiration time functionality.

### Unit tests for use cases:
* **AuthUseCase**: Added tests to ensure proper login behavior, including handling valid credentials, invalid passwords, and non-existent users.

### Unit tests for security components:
* **PasswordValidator**: Added tests to verify password validation logic, including matching passwords, non-matching passwords, and exception handling