### PR TITLE
Feature/reset password

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,12 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
             cd ~/deploy/${{ github.event.repository.name }}
             echo "SWAGGER_SERVER_URL=${{ secrets.SWAGGER_SERVER_URL }}" > .env
+            echo "RABBITMQ_HOST=${{ secrets.RABBITMQ_HOST }}" >> .env
+            echo "RABBITMQ_USERNAME=${{ secrets.RABBITMQ_USERNAME }}" >> .env
+            echo "RABBITMQ_PASSWORD=${{ secrets.RABBITMQ_PASSWORD }}" >> .env
+            echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
+            echo "DATASOURCE_USERNAME=${{ secrets.DATASOURCE_USERNAME }}" >> .env
+            echo "DATASOURCE_PASSWORD=${{ secrets.DATASOURCE_PASSWORD }}" >> .env
             docker compose down --remove-orphans
             docker compose build
             docker compose up -d --remove-orphans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,24 @@ services:
     build: .
     container_name: gtu-auth-service
     environment:
+      - SPRING_DATASOURCE_URL=jdbc:h2:file:/data/reset_tokens
+      - SPRING_DATASOURCE_USERNAME=${DATASOURCE_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${DATASOURCE_PASSWORD}
       - EUREKA_SERVER_HOST=discovery-server
       - EUREKA_SERVER_PORT=8761
-      - SERVER_PORT=0
       - SWAGGER_SERVER_URL=${SWAGGER_SERVER_URL}
-      - JWT_SECRET=LbKuwcGpBGZm5tKJ7MmYQa9NfKtJzYMkVwsDsbUwKyA=
+      - SPRING_RABBITMQ_HOST=${RABBITMQ_HOST}
+      - SPRING_RABBITMQ_PORT=5672
+      - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USERNAME}
+      - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      - RESET_LINK_PASSENGER=https://frontend-app.com/reset-password
+      - RESET_LINK_DRIVER=https://frontend-app.com/reset-password
+      - RESET_LINK_ADMIN=https://frontend-app.com/reset-password
+      - RESET_LINK_SUPERADMIN=https://frontend-app.com/reset-password
+      - SERVER_PORT=0
+    volumes:
+      - ./data:/data
     networks:
       - shared_network
 networks:

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,20 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/gtu/auth_service/application/dto/ResponseDTO.java
+++ b/src/main/java/com/gtu/auth_service/application/dto/ResponseDTO.java
@@ -1,0 +1,22 @@
+package com.gtu.auth_service.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO that represents the response of an API endpoint")
+public class ResponseDTO<T> {
+
+    @Schema(description = "Message of the response", example = "Request was successful")
+    private String message;
+
+    @Schema(description = "Data of the response")
+    private T data;
+
+    @Schema(description = "Status code of the response", example = "200")
+    private int status;
+}

--- a/src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java
+++ b/src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java
@@ -1,0 +1,160 @@
+package com.gtu.auth_service.application.service;
+
+import com.gtu.auth_service.domain.model.ResetToken;
+import com.gtu.auth_service.domain.model.Role;
+import com.gtu.auth_service.domain.repository.ResetTokenRepository;
+import com.gtu.auth_service.domain.service.ResetPasswordService;
+import com.gtu.auth_service.infrastructure.client.PassengerClient;
+import com.gtu.auth_service.infrastructure.client.UserClient;
+import com.gtu.auth_service.infrastructure.client.dto.UserServiceResponse;
+import com.gtu.auth_service.infrastructure.messaging.event.ResetPasswordEvent;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class ResetPasswordServiceImpl implements ResetPasswordService {
+
+    private final UserClient userClient;
+    private final PassengerClient passengerClient;
+    private final ResetTokenRepository resetTokenRepository;
+    private final RabbitTemplate rabbitTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${reset.links.passenger}")
+    private String passengerResetLink;
+
+    @Value("${reset.links.driver}")
+    private String driverResetLink;
+
+    @Value("${reset.links.admin}")
+    private String adminResetLink;
+
+    @Value("${reset.links.superadmin}")
+    private String superadminResetLink;
+
+    private final String resetExchange = "reset-password.exchange";
+    private final String resetRoutingKey = "reset-password.routingkey";
+
+    public ResetPasswordServiceImpl(UserClient userClient, PassengerClient passengerClient,
+                                   ResetTokenRepository resetTokenRepository, RabbitTemplate rabbitTemplate,
+                                   ObjectMapper objectMapper) {
+        this.userClient = userClient;
+        this.passengerClient = passengerClient;
+        this.resetTokenRepository = resetTokenRepository;
+        this.rabbitTemplate = rabbitTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void requestPasswordReset(String email) {
+        UserServiceResponse target = null;
+
+        try {
+            target = userClient.getUserByEmail(email);
+        } catch (Exception e) {
+            try {
+                target = passengerClient.getPassengerByEmail(email);
+            } catch (Exception ex) {
+                throw new IllegalArgumentException("No user or passenger found with email: " + email);
+            }
+        }
+        resetTokenRepository.findByEmailAndUsedFalse(email).ifPresent(token -> {
+            throw new IllegalStateException("A reset token is already pending for this email: " + email);
+        });
+
+        String token = UUID.randomUUID().toString();
+        LocalDateTime expiryDate = LocalDateTime.now().plusMinutes(15);
+        ResetToken resetToken = new ResetToken();
+        resetToken.setToken(token);
+        resetToken.setEmail(email);
+        resetToken.setExpiryDate(expiryDate);
+        resetTokenRepository.save(resetToken);
+
+        String resetLink = generateResetLink(target, token);
+        sendResetEmailEvent(email, getRole(target), resetLink);
+    }
+
+    @Override
+    public String generateResetLink(UserServiceResponse user, String token) {
+        String baseUrl = user.getRole() != null ? switch (user.getRole().toUpperCase()) {
+            case "DRIVER" -> driverResetLink;
+            case "ADMIN" -> adminResetLink;
+            case "SUPERADMIN" -> superadminResetLink;
+            default -> throw new IllegalArgumentException("Unsupported role: " + user.getRole());
+        } : passengerResetLink;
+        return baseUrl + "?token=" + token;
+    }
+
+    private Role getRole(UserServiceResponse user) {
+        return user.getRole() != null ? mapToRole(user.getRole()) : Role.PASSENGER;
+    }
+
+    private Role mapToRole(String role) {
+        if (role == null) return Role.PASSENGER;
+        return switch (role.toUpperCase()) {
+            case "SUPERADMIN" -> Role.SUPERADMIN;
+            case "ADMIN" -> Role.ADMIN;
+            case "DRIVER" -> Role.DRIVER;
+            default -> Role.PASSENGER;
+        };
+    }
+
+    @Override
+    public void sendResetEmailEvent(String to, Role role, String resetLink) {
+        ResetPasswordEvent event = new ResetPasswordEvent(to, role, resetLink);
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            rabbitTemplate.convertAndSend(resetExchange, resetRoutingKey, message);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to send reset email event: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void resetPassword(String token, String newPassword) {
+        ResetToken resetToken = resetTokenRepository.findByToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid or expired token"));
+
+        if (resetToken.getExpiryDate().isBefore(LocalDateTime.now()) || resetToken.isUsed()) {
+            throw new IllegalArgumentException("Token has expired or already used");
+        }
+
+        Long userId = getUserIdByEmail(resetToken.getEmail());
+        if (userId != null) {
+            userClient.resetPassword(userId, newPassword);
+        } else {
+            Long passengerId = getPassengerIdByEmail(resetToken.getEmail());
+            if (passengerId != null) {
+                passengerClient.resetPassword(passengerId, newPassword);
+            } else {
+                throw new IllegalArgumentException("No user or passenger found with email: " + resetToken.getEmail());
+            }
+        }
+
+        resetToken.setUsed(true);
+        resetTokenRepository.save(resetToken);
+    }
+
+    public Long getUserIdByEmail(String email) {
+        try {
+            UserServiceResponse user = userClient.getUserByEmail(email);
+            return user != null ? user.getId() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public Long getPassengerIdByEmail(String email) {
+        try {
+            UserServiceResponse passenger = passengerClient.getPassengerByEmail(email);
+            return passenger != null ? passenger.getId() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/gtu/auth_service/application/usecase/AuthUseCase.java
+++ b/src/main/java/com/gtu/auth_service/application/usecase/AuthUseCase.java
@@ -8,16 +8,19 @@ import com.gtu.auth_service.infrastructure.security.PasswordValidator;
 import com.gtu.auth_service.domain.model.AuthUser;
 import com.gtu.auth_service.domain.service.AuthService;
 import com.gtu.auth_service.domain.service.JwtService;
+import com.gtu.auth_service.domain.service.ResetPasswordService;
 
 @Service
 public class AuthUseCase {
     private final AuthService authService;
     private final JwtService jwtService;
+    private final ResetPasswordService resetPasswordService;
     private final PasswordValidator PasswordValidator;
 
-    public AuthUseCase(AuthService authService, JwtService jwtService, PasswordValidator PasswordValidator) {
+    public AuthUseCase(AuthService authService, JwtService jwtService, ResetPasswordService resetPasswordService, PasswordValidator PasswordValidator) {
         this.authService = authService;
         this.jwtService = jwtService;
+        this.resetPasswordService = resetPasswordService;
         this.PasswordValidator = PasswordValidator;
     }
 
@@ -37,5 +40,13 @@ public class AuthUseCase {
                 user.email(),
                 user.role().name()
         );
+    }
+
+    public void resetPasswordRequest(String email){
+        resetPasswordService.requestPasswordReset(email);
+    }
+
+    public void resetPassword(String token, String newPassword){
+        resetPasswordService.resetPassword(token, newPassword);
     }
 }

--- a/src/main/java/com/gtu/auth_service/domain/model/ResetToken.java
+++ b/src/main/java/com/gtu/auth_service/domain/model/ResetToken.java
@@ -1,0 +1,25 @@
+package com.gtu.auth_service.domain.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetToken {
+    private Long id;
+
+    private String token;
+
+    private String email;
+
+    private LocalDateTime expiryDate;
+
+    private boolean used;
+}

--- a/src/main/java/com/gtu/auth_service/domain/model/Role.java
+++ b/src/main/java/com/gtu/auth_service/domain/model/Role.java
@@ -3,5 +3,6 @@ package com.gtu.auth_service.domain.model;
 public enum Role {
     SUPERADMIN,
     ADMIN,
-    DRIVER
+    DRIVER, 
+    PASSENGER
 }

--- a/src/main/java/com/gtu/auth_service/domain/repository/ResetTokenRepository.java
+++ b/src/main/java/com/gtu/auth_service/domain/repository/ResetTokenRepository.java
@@ -1,0 +1,12 @@
+package com.gtu.auth_service.domain.repository;
+
+import com.gtu.auth_service.domain.model.ResetToken;
+
+import java.util.Optional;
+
+public interface ResetTokenRepository {
+    Optional<ResetToken> findByToken(String token);
+    Optional<ResetToken> findByEmailAndUsedFalse(String email);
+    void save(ResetToken resetToken);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/gtu/auth_service/domain/service/ResetPasswordService.java
+++ b/src/main/java/com/gtu/auth_service/domain/service/ResetPasswordService.java
@@ -1,0 +1,11 @@
+package com.gtu.auth_service.domain.service;
+
+import com.gtu.auth_service.domain.model.Role;
+import com.gtu.auth_service.infrastructure.client.dto.UserServiceResponse;
+
+public interface ResetPasswordService {
+    void requestPasswordReset(String email);
+    String generateResetLink(UserServiceResponse user, String token);
+    void sendResetEmailEvent(String to, Role role, String resetLink);
+    void resetPassword(String token, String newPassword);
+}

--- a/src/main/java/com/gtu/auth_service/infrastructure/JpaResetTokenRepository.java
+++ b/src/main/java/com/gtu/auth_service/infrastructure/JpaResetTokenRepository.java
@@ -1,0 +1,21 @@
+package com.gtu.auth_service.infrastructure;
+
+import org.springframework.stereotype.Repository;
+
+import com.gtu.auth_service.infrastructure.entities.ResetTokenEntity;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+@Repository
+public interface JpaResetTokenRepository extends JpaRepository<ResetTokenEntity, Long> {
+    @Query("SELECT rt FROM ResetTokenEntity rt WHERE rt.token = ?1")
+    Optional<ResetTokenEntity> findByToken(String token);
+
+    @Query("SELECT rt FROM ResetTokenEntity rt WHERE rt.email = ?1 AND rt.used = false")
+    Optional<ResetTokenEntity> findByEmailAndUsedFalse(String email);
+
+    @Query("SELECT rt FROM ResetTokenEntity rt WHERE rt.email = ?1")
+    Optional<ResetTokenEntity> findByEmail(String email);
+}

--- a/src/main/java/com/gtu/auth_service/infrastructure/ResetTokenRepositoryImpl.java
+++ b/src/main/java/com/gtu/auth_service/infrastructure/ResetTokenRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.gtu.auth_service.infrastructure;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.gtu.auth_service.domain.model.ResetToken;
+import com.gtu.auth_service.domain.repository.ResetTokenRepository;
+import com.gtu.auth_service.infrastructure.mappers.ResetTokenMapper;
+
+@Repository
+public class ResetTokenRepositoryImpl implements ResetTokenRepository {
+
+    private final JpaResetTokenRepository jpaResetTokenRepository;
+
+    public ResetTokenRepositoryImpl(JpaResetTokenRepository jpaResetTokenRepository) {
+        this.jpaResetTokenRepository = jpaResetTokenRepository;
+    }
+
+    @Override
+    public Optional<ResetToken> findByToken(String token) {
+        return jpaResetTokenRepository.findByToken(token)
+                .map(ResetTokenMapper::toDomain);
+    }
+
+    @Override
+    public Optional<ResetToken> findByEmailAndUsedFalse(String email) {
+        return jpaResetTokenRepository.findByEmailAndUsedFalse(email)
+                .map(ResetTokenMapper::toDomain);
+    }
+
+    @Override
+    public void save(ResetToken resetToken) {
+        jpaResetTokenRepository.save(ResetTokenMapper.toEntity(resetToken));
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return jpaResetTokenRepository.findByEmail(email).isPresent();
+    }
+}

--- a/src/main/java/com/gtu/auth_service/infrastructure/client/PassengerClient.java
+++ b/src/main/java/com/gtu/auth_service/infrastructure/client/PassengerClient.java
@@ -3,6 +3,8 @@ package com.gtu.auth_service.infrastructure.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.gtu.auth_service.infrastructure.client.dto.UserServiceResponse;
@@ -13,4 +15,6 @@ public interface PassengerClient {
     @GetMapping
     UserServiceResponse getPassengerByEmail(@RequestParam String email);
 
+    @PutMapping("/{id}/reset-password")
+    void resetPassword(@PathVariable Long id, @RequestParam String newPassword);
 }

--- a/src/main/java/com/gtu/auth_service/infrastructure/client/UserClient.java
+++ b/src/main/java/com/gtu/auth_service/infrastructure/client/UserClient.java
@@ -2,6 +2,8 @@ package com.gtu.auth_service.infrastructure.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.gtu.auth_service.infrastructure.client.dto.UserServiceResponse;
@@ -11,4 +13,7 @@ public interface UserClient {
     
     @GetMapping
     UserServiceResponse getUserByEmail(@RequestParam String email);
+
+    @PutMapping("/{id}/reset-password")
+    void resetPassword(@PathVariable Long id, @RequestParam String newPassword);
 }

--- a/src/main/java/com/gtu/auth_service/infrastructure/entities/ResetTokenEntity.java
+++ b/src/main/java/com/gtu/auth_service/infrastructure/entities/ResetTokenEntity.java
@@ -1,0 +1,31 @@
+package com.gtu.auth_service.infrastructure.entities;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "reset_tokens")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetTokenEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    @Column(nullable = false)
+    private boolean used = false;
+}

--- a/src/main/java/com/gtu/auth_service/infrastructure/mappers/ResetTokenMapper.java
+++ b/src/main/java/com/gtu/auth_service/infrastructure/mappers/ResetTokenMapper.java
@@ -1,0 +1,30 @@
+package com.gtu.auth_service.infrastructure.mappers;
+
+import com.gtu.auth_service.domain.model.ResetToken;
+import com.gtu.auth_service.infrastructure.entities.ResetTokenEntity;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ResetTokenMapper {
+    
+    public ResetTokenEntity toEntity(ResetToken resetToken) {
+        return new ResetTokenEntity(
+            resetToken.getId(),
+            resetToken.getToken(),
+            resetToken.getEmail(),
+            resetToken.getExpiryDate(),
+            resetToken.isUsed()
+        );
+    }
+
+    public ResetToken toDomain(ResetTokenEntity entity) {
+        return new ResetToken(
+            entity.getId(),
+            entity.getToken(),
+            entity.getEmail(),
+            entity.getExpiryDate(),
+            entity.isUsed()
+        );
+    }
+}

--- a/src/main/java/com/gtu/auth_service/infrastructure/messaging/event/ResetPasswordEvent.java
+++ b/src/main/java/com/gtu/auth_service/infrastructure/messaging/event/ResetPasswordEvent.java
@@ -1,0 +1,17 @@
+package com.gtu.auth_service.infrastructure.messaging.event;
+
+import com.gtu.auth_service.domain.model.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetPasswordEvent {
+    private String to;
+    private Role role;
+    private String resetLink;
+}

--- a/src/main/java/com/gtu/auth_service/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gtu/auth_service/presentation/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.gtu.auth_service.presentation.exception;
 
 import com.gtu.auth_service.application.dto.ErrorResponseDTO;
+
+import feign.FeignException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -19,5 +22,21 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleGeneralException(Exception ex) {
         ErrorResponseDTO error = new ErrorResponseDTO("An unexpected error occurred", HttpStatus.INTERNAL_SERVER_ERROR.value(), "Internal Server Error");
         return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<ErrorResponseDTO> handleFeignException(FeignException ex) {
+        HttpStatus status = HttpStatus.resolve(ex.status());
+        if (status == null) {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        ErrorResponseDTO error = new ErrorResponseDTO(ex.getMessage(), status.value(), status.getReasonPhrase());
+        return new ResponseEntity<>(error, status);
+    }
+
+    @ExceptionHandler(FeignException.NotFound.class)
+    public ResponseEntity<ErrorResponseDTO> handleFeignNotFound(FeignException.NotFound ex) {
+        ErrorResponseDTO error = new ErrorResponseDTO("User not found in remote service", HttpStatus.NOT_FOUND.value(), "Not Found");
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/gtu/auth_service/presentation/rest/AuthController.java
+++ b/src/main/java/com/gtu/auth_service/presentation/rest/AuthController.java
@@ -3,12 +3,13 @@ package com.gtu.auth_service.presentation.rest;
 import com.gtu.auth_service.application.dto.LoginRequestDTO;
 import com.gtu.auth_service.application.dto.LoginResponseDTO;
 import com.gtu.auth_service.application.usecase.AuthUseCase;
+import com.gtu.auth_service.application.dto.ResponseDTO;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/test")
+@RequestMapping("/")
 public class AuthController {
 
     private final AuthUseCase authUseCase;
@@ -18,8 +19,20 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO request) {
+    public ResponseEntity<ResponseDTO<LoginResponseDTO>> login(@Valid @RequestBody LoginRequestDTO request) {
         LoginResponseDTO response = authUseCase.login(request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(200).body(new ResponseDTO<>("Login successful", response, 200));
+    }
+
+    @PostMapping("/reset-password-request")
+    public ResponseEntity<ResponseDTO<Void>> resetPasswordRequest(@RequestParam String email) {
+        authUseCase.resetPasswordRequest(email);
+        return ResponseEntity.ok(new ResponseDTO<>("Password reset request successful", null, 200));
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<ResponseDTO<Void>> resetPassword(@RequestParam String token, @RequestParam String newPassword) {
+        authUseCase.resetPassword(token, newPassword);
+        return ResponseEntity.ok(new ResponseDTO<>("Password reset successful", null, 200));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,14 +1,32 @@
 spring.application.name=gtu-auth-service
 server.port=${SERVER_PORT:8081}
 
-
 eureka.instance.instance-id=${spring.application.name}:${spring.application.instance_id:${random.value}}
 eureka.client.service-url.defaultZone=http://${EUREKA_SERVER_HOST:localhost}:${EUREKA_SERVER_PORT:8761}/eureka/
 eureka.client.register-with-eureka=true
 eureka.client.fetch-registry=true
 
-
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.enabled=false
 
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=${DATASOURCE_USERNAME}
+spring.datasource.password=${DATASOURCE_PASSWORD}
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+
+spring.rabbitmq.host=${RABBITMQ_HOST}
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=${RABBITMQ_USERNAME}
+spring.rabbitmq.password=${RABBITMQ_PASSWORD}
+
+rabbitmq.exchange.reset=reset-password.exchange
+rabbitmq.routingkey.reset=reset-password.routingkey
+
+reset.links.passenger=${RESET_LINK_PASSENGER}
+reset.links.driver=${RESET_LINK_DRIVER}
+reset.links.admin=${RESET_LINK_ADMIN}
+reset.links.superadmin=${RESET_LINK_SUPERADMIN}
 


### PR DESCRIPTION
This pull request introduces a comprehensive password reset feature to the `gtu-auth-service`. It includes changes to the deployment configuration, database integration, service layer, and client communication for handling password reset requests. The most important changes are grouped into themes: deployment updates, database and dependency integration, service implementation, and client communication enhancements.

### Deployment Updates
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R67-R72): Added environment variables for RabbitMQ, JWT, and datasource credentials to the `.env` file during deployment.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R6-R23): Updated service configuration to include RabbitMQ and datasource environment variables, reset link URLs, and mounted a volume for token persistence.

### Database and Dependency Integration
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R75-R88): Added dependencies for Spring Data JPA, Spring AMQP, and H2 database to support token persistence and RabbitMQ messaging.
* [`src/main/java/com/gtu/auth_service/infrastructure/entities/ResetTokenEntity.java`](diffhunk://#diff-2c4d0e041b10fe191fbf816ddb6edd64b4b3a08febd021684663fea06eb6bdbaR1-R31): Created a JPA entity for reset tokens with fields for token, email, expiry date, and usage status.
* [`src/main/java/com/gtu/auth_service/infrastructure/mappers/ResetTokenMapper.java`](diffhunk://#diff-04b6e1db3f8fd7fb48cc9fcc3b0cdc413af48312eef489a39056621e1ff778c3R1-R30): Added a mapper to convert between `ResetToken` domain model and `ResetTokenEntity`.

### Service Implementation
* [`src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java`](diffhunk://#diff-f19a6fcfa99d1e0d96a56c6170a816a89cc0217de84c01a5c5c7c9753924b9d8R1-R160): Implemented the logic for generating reset tokens, sending reset email events via RabbitMQ, and resetting passwords.
* [`src/main/java/com/gtu/auth_service/domain/service/ResetPasswordService.java`](diffhunk://#diff-e06061e84480b35e442d926d1b90b5cef34c06c1d2f02b2756ab4ebf03200686R1-R11): Defined the interface for the password reset service.

### Client Communication Enhancements
* `src/main/java/com/gtu/auth_service/infrastructure/client/PassengerClient.java` and `UserClient.java`: Added methods for updating passwords via REST endpoints. [[1]](diffhunk://#diff-903d4c87e6e364e2f90827a9fbd92ee874c0dc27c05e879a58c41cff1558941bR18-R19) [[2]](diffhunk://#diff-02e4fd50936295e0612412cb3d918336e9c479a448a33eddf9f1b28abdac6806R16-R18)
* [`src/main/java/com/gtu/auth_service/infrastructure/messaging/event/ResetPasswordEvent.java`](diffhunk://#diff-78f25726276195f7fc6f8716e0b76707b768fe5fe80faa02014374520906f786R1-R17): Created an event class for RabbitMQ messaging to handle password reset emails.