### PR TITLE
Refactor and enhance unit tests for authentication and password reset…

### DIFF
--- a/src/test/java/com/gtu/auth_service/application/service/AuthServiceImplTest.java
+++ b/src/test/java/com/gtu/auth_service/application/service/AuthServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.gtu.auth_service.application.service;
 
+import com.gtu.auth_service.application.dto.LoginRequestDTO;
 import com.gtu.auth_service.domain.model.AuthUser;
 import com.gtu.auth_service.domain.model.Role;
 import com.gtu.auth_service.infrastructure.client.PassengerClient;
@@ -13,6 +14,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 class AuthServiceImplTest {
@@ -45,7 +47,7 @@ class AuthServiceImplTest {
     }
 
     @Test
-    void findUserByEmail_WhenNoUserOrPassengerExists_ShouldReturnNull() {
+    void findUserByEmail_WhenNoUserDoesNotExist_ShouldReturnNull() {
         when(userClient.getUserByEmail("nonexistent@example.com")).thenReturn(null);
         when(passengerClient.getPassengerByEmail("nonexistent@example.com")).thenReturn(null);
 
@@ -55,27 +57,37 @@ class AuthServiceImplTest {
     }
 
     @Test
-    void mapToRole_WhenValidRole_ShouldMapCorrectly() {
+    void mapToRole_WhenRoleIsSuperAdmin_ShouldReturnSuperAdmin() {
         assertEquals(Role.SUPERADMIN, authService.mapToRole("SUPERADMIN"));
+    }
+
+    @Test
+    void mapToRole_WhenRoleIsAdmin_ShouldReturnAdmin() {
         assertEquals(Role.ADMIN, authService.mapToRole("ADMIN"));
+    }
+
+    @Test
+    void mapToRole_WhenRoleIsDriver_ShouldReturnDriver() {
         assertEquals(Role.DRIVER, authService.mapToRole("DRIVER"));
     }
 
     @Test
-    void mapToRole_WhenNullRole_ShouldThrowIllegalArgumentException() {
-        try {
-            authService.mapToRole(null);
-        } catch (IllegalArgumentException e) {
-            assertEquals("Role cannot be null", e.getMessage());
-        }
+    void mapToRole_WhenRoleIsNull_ShouldThrowException() {
+        IllegalArgumentException exception = 
+            assertThrows(IllegalArgumentException.class, () -> authService.mapToRole(null));
+        assertEquals("Role cannot be null", exception.getMessage());
     }
 
     @Test
-    void mapToRole_WhenInvalidRole_ShouldThrowIllegalArgumentException() {
-        try {
-            authService.mapToRole("INVALID");
-        } catch (IllegalArgumentException e) {
-            assertEquals("Invalid role: INVALID", e.getMessage());
-        }
-    } 
+    void mapToRole_WhenRoleIsInvalid_ShouldThrowException() {
+        IllegalArgumentException exception = 
+            assertThrows(IllegalArgumentException.class, () -> authService.mapToRole("INVALID"));
+        assertEquals("Invalid role: INVALID", exception.getMessage());
+    }
+
+    @Test
+    void authenticate_ShouldThrowUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, 
+            () -> authService.authenticate(new LoginRequestDTO("email", "pass")));
+    }
 }

--- a/src/test/java/com/gtu/auth_service/application/service/JwtServiceImplTest.java
+++ b/src/test/java/com/gtu/auth_service/application/service/JwtServiceImplTest.java
@@ -2,6 +2,7 @@ package com.gtu.auth_service.application.service;
 
 import com.gtu.auth_service.domain.model.AuthUser;
 import com.gtu.auth_service.domain.model.Role;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -30,7 +31,7 @@ class JwtServiceImplTest {
     }
 
     @Test
-    void generateToken_WhenUserProvided_ShouldReturnNonNullToken() {
+    void generateToken_ShouldReturnValidJwtToken_WhenUserProvided() {
         AuthUser user = new AuthUser(1L, "John Doe", "john.doe@example.com", "password", Role.DRIVER);
         String token = jwtService.generateToken(user);
 
@@ -39,8 +40,17 @@ class JwtServiceImplTest {
     }
 
     @Test
-    void getExpirationTime_ShouldReturn30Minutes() {
+    void getExpirationTime_ShouldReturnDefault30Minutes() {
         long expiration = jwtService.getExpirationTime();
-        assertEquals(30L * 60000, expiration); // 30 minutes in milliseconds
+        assertEquals(30L * 60000, expiration); 
+    }
+
+    @Test
+    void generateToken_WhenFieldsAreNull_ShouldStillGenerateToken() {
+        AuthUser user = new AuthUser(null, null, null, null, Role.DRIVER);
+        String token = jwtService.generateToken(user);
+
+        assertNotNull(token);
+        assertTrue(token.length() > 0);
     }
 }

--- a/src/test/java/com/gtu/auth_service/application/service/ResetPasswordServiceImplTest.java
+++ b/src/test/java/com/gtu/auth_service/application/service/ResetPasswordServiceImplTest.java
@@ -1,0 +1,149 @@
+package com.gtu.auth_service.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gtu.auth_service.domain.model.Role;
+import com.gtu.auth_service.domain.repository.ResetTokenRepository;
+import com.gtu.auth_service.infrastructure.client.PassengerClient;
+import com.gtu.auth_service.infrastructure.client.UserClient;
+import com.gtu.auth_service.infrastructure.client.dto.UserServiceResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ResetPasswordServiceImplTest {
+
+    @Mock
+    private UserClient userClient;
+
+    @Mock
+    private PassengerClient passengerClient;
+
+    @Mock
+    private ResetTokenRepository resetTokenRepository;
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private ResetPasswordServiceImpl resetPasswordService;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        objectMapper = new ObjectMapper();
+        resetPasswordService = new ResetPasswordServiceImpl(
+                userClient,
+                passengerClient,
+                resetTokenRepository,
+                rabbitTemplate,
+                objectMapper
+        );
+
+        setField("passengerResetLink", "http://reset/passenger");
+        setField("driverResetLink", "http://reset/driver");
+        setField("adminResetLink", "http://reset/admin");
+        setField("superadminResetLink", "http://reset/superadmin");
+    }
+
+    private void setField(String name, String value) throws Exception {
+        var field = ResetPasswordServiceImpl.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(resetPasswordService, value);
+    }
+
+    @Test
+    void generateResetLink_ShouldReturnDriverResetLink() {
+        UserServiceResponse user = new UserServiceResponse(1L, "John", "john@example.com", "pass", "DRIVER");
+        String token = UUID.randomUUID().toString();
+
+        String result = resetPasswordService.generateResetLink(user, token);
+
+        assertTrue(result.startsWith("http://reset/driver"));
+        assertTrue(result.contains(token));
+    }
+
+    @Test
+    void generateResetLink_ShouldReturnPassengerLink_WhenRoleIsNull() {
+        UserServiceResponse user = new UserServiceResponse(1L, "Jane", "jane@example.com", "pass", null);
+        String token = "abc123";
+
+        String result = resetPasswordService.generateResetLink(user, token);
+
+        assertEquals("http://reset/passenger?token=abc123", result);
+    }
+
+    @Test
+    void generateResetLink_ShouldThrowException_ForInvalidRole() {
+        UserServiceResponse user = new UserServiceResponse(1L, "Fake", "fake@example.com", "pass", "HACKER");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                resetPasswordService.generateResetLink(user, "token123"));
+
+        assertEquals("Unsupported role: HACKER", ex.getMessage());
+    }
+
+    @Test
+    void getUserIdByEmail_ShouldReturnId_WhenUserExists() {
+        UserServiceResponse user = new UserServiceResponse(10L, "X", "x@example.com", "pass", "ADMIN");
+        when(userClient.getUserByEmail("x@example.com")).thenReturn(user);
+
+        Long result = resetPasswordService.getUserIdByEmail("x@example.com");
+
+        assertEquals(10L, result);
+    }
+
+    @Test
+    void getUserIdByEmail_ShouldReturnNull_WhenNotFound() {
+        when(userClient.getUserByEmail("x@example.com")).thenThrow(RuntimeException.class);
+
+        Long result = resetPasswordService.getUserIdByEmail("x@example.com");
+
+        assertNull(result);
+    }
+
+    @Test
+    void sendResetEmailEvent_ShouldPublishMessage() {
+        doNothing().when(rabbitTemplate).convertAndSend(anyString(), anyString(), anyString());
+
+        assertDoesNotThrow(() ->
+                resetPasswordService.sendResetEmailEvent("user@example.com", Role.ADMIN, "http://reset/admin?token=abc"));
+    }
+
+    @Test
+    void sendResetEmailEvent_ShouldThrowException_WhenObjectMapperFails() throws Exception {
+        ResetPasswordServiceImpl service = new ResetPasswordServiceImpl(
+                userClient, passengerClient, resetTokenRepository, rabbitTemplate, mock(ObjectMapper.class)
+        );
+        setFieldOnInstance(service, "adminResetLink", "http://reset/admin");
+        setFieldOnInstance(service, "driverResetLink", "http://reset/driver");
+        setFieldOnInstance(service, "passengerResetLink", "http://reset/passenger");
+        setFieldOnInstance(service, "superadminResetLink", "http://reset/superadmin");
+
+        ObjectMapper failingMapper = mock(ObjectMapper.class);
+        when(failingMapper.writeValueAsString(any())).thenThrow(new RuntimeException("Mapper error"));
+
+        var serviceWithFailingMapper = new ResetPasswordServiceImpl(
+                userClient, passengerClient, resetTokenRepository, rabbitTemplate, failingMapper);
+
+        setFieldOnInstance(serviceWithFailingMapper, "adminResetLink", "http://reset/admin");
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                serviceWithFailingMapper.sendResetEmailEvent("x", Role.ADMIN, "http://link"));
+
+        assertTrue(ex.getMessage().contains("Failed to send reset email event"));
+    }
+
+    private void setFieldOnInstance(Object target, String fieldName, String value) throws Exception {
+        var field = ResetPasswordServiceImpl.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
+++ b/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
@@ -6,6 +6,7 @@ import com.gtu.auth_service.application.service.AuthServiceImpl;
 import com.gtu.auth_service.application.service.JwtServiceImpl;
 import com.gtu.auth_service.domain.model.AuthUser;
 import com.gtu.auth_service.domain.model.Role;
+import com.gtu.auth_service.domain.service.ResetPasswordService;
 import com.gtu.auth_service.infrastructure.security.PasswordValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,9 @@ public class AuthUseCaseTest {
     @Mock
     private PasswordValidator passwordValidator;
 
+    @Mock
+    private ResetPasswordService resetPasswordService;
+
     @InjectMocks
     private AuthUseCase authUseCase;
 
@@ -36,7 +40,7 @@ public class AuthUseCaseTest {
     }
 
     @Test
-    void login_WhenValidCredentials_ShouldReturnLoginResponse() {
+    void login_ShouldReturnLoginResponse_WhenCredentialsAreValid() {
         LoginRequestDTO request = new LoginRequestDTO("john.doe@example.com", "password123");
         AuthUser user = new AuthUser(1L, "John Doe", "john.doe@example.com", "encodedPass", Role.DRIVER);
         String token = "mocked-jwt-token";
@@ -55,7 +59,7 @@ public class AuthUseCaseTest {
     }
 
     @Test
-    void login_WhenUserNotFound_ShouldThrowIllegalArgumentException() {
+    void login_ShouldThrowException_WhenUserNotFound() {
         LoginRequestDTO request = new LoginRequestDTO("nonexistent@example.com", "password123");
 
         when(authService.findUserByEmail("nonexistent@example.com")).thenReturn(null);
@@ -64,7 +68,7 @@ public class AuthUseCaseTest {
     }
 
     @Test
-    void login_WhenInvalidPassword_ShouldThrowIllegalArgumentException() {
+    void login_ShouldThrowException_WhenInvalidPassword() {
         LoginRequestDTO request = new LoginRequestDTO("john.doe@example.com", "wrongpass");
         AuthUser user = new AuthUser(1L, "John Doe", "john.doe@example.com", "encodedPass", Role.DRIVER);
 
@@ -72,5 +76,24 @@ public class AuthUseCaseTest {
         when(passwordValidator.validate("wrongpass", "encodedPass")).thenReturn(false);
 
         assertThrows(IllegalArgumentException.class, () -> authUseCase.login(request));
+    }
+
+    @Test
+    void resetPasswordRequest_ShouldCallResetPasswordService() {
+        String email = "john.doe@example.com";
+
+        authUseCase.resetPasswordRequest(email);
+
+        verify(resetPasswordService, times(1)).requestPasswordReset(email);
+    }
+
+    @Test
+    void resetPassword_ShouldCallResetPasswordService() {
+        String token = "reset-token";
+        String newPassword = "newPassword123";
+
+        authUseCase.resetPassword(token, newPassword);
+
+        verify(resetPasswordService, times(1)).resetPassword(token, newPassword);
     }
 }

--- a/src/test/java/com/gtu/auth_service/infrastructure/security/PasswordValidatorTest.java
+++ b/src/test/java/com/gtu/auth_service/infrastructure/security/PasswordValidatorTest.java
@@ -19,7 +19,7 @@ class PasswordValidatorTest {
     }
 
     @Test
-    void validate_WhenPasswordMatches_ShouldReturnTrue() {
+    void validate_ShouldReturnTrue_WhenPasswordMatches() {
         String rawPassword = "password123";
         String encodedPassword = new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder().encode(rawPassword);
 
@@ -27,7 +27,7 @@ class PasswordValidatorTest {
     }
 
     @Test
-    void validate_WhenPasswordDoesNotMatch_ShouldReturnFalse() {
+    void validate_ShouldReturnFalse_WhenPasswordDoesNotMatch() {
         String rawPassword = "password123";
         String wrongEncodedPassword = new BCryptPasswordEncoder().encode("wrongpass");
 
@@ -35,8 +35,8 @@ class PasswordValidatorTest {
     }
 
     @Test
-    void validate_WhenExceptionOccurs_ShouldReturnFalse() {
-        String rawPassword = null; 
+    void validate_ShouldReturnFalse_WhenExceptionOccurs() {
+        String rawPassword = null;
         String encodedPassword = "invalidEncoded";
 
         assertFalse(passwordValidator.validate(rawPassword, encodedPassword));

--- a/src/test/java/com/gtu/auth_service/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/com/gtu/auth_service/presentation/rest/AuthControllerTest.java
@@ -1,0 +1,134 @@
+package com.gtu.auth_service.presentation.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gtu.auth_service.application.dto.LoginRequestDTO;
+import com.gtu.auth_service.application.dto.LoginResponseDTO;
+import com.gtu.auth_service.application.usecase.AuthUseCase;
+import com.gtu.auth_service.presentation.exception.GlobalExceptionHandler;
+import com.gtu.auth_service.presentation.exception.LogPublisher;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private AuthUseCase authUseCase;
+
+    @Mock
+    private LogPublisher logPublisher;
+
+    @InjectMocks
+    private AuthController authController;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(authController)
+                .setControllerAdvice(new GlobalExceptionHandler((Mockito.mock(LogPublisher.class))))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void login_ShouldReturnLoginResponseDTO_WhenCredentialsAreValid() throws Exception {
+        LoginRequestDTO request = new LoginRequestDTO("john@example.com", "password123");
+        LoginResponseDTO response = new LoginResponseDTO("jwt-token", 1L, "John", "john@example.com", "DRIVER");
+
+        Mockito.when(authUseCase.login(Mockito.any(LoginRequestDTO.class))).thenReturn(response);
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Login successful"))
+                .andExpect(jsonPath("$.data.accessToken").value("jwt-token"))
+                .andExpect(jsonPath("$.data.email").value("john@example.com"))
+                .andExpect(jsonPath("$.data.role").value("DRIVER"));
+    }
+
+    @Test
+    void login_ShouldReturnBadRequest_WhenUserNotFound() throws Exception {
+        LoginRequestDTO request = new LoginRequestDTO("wrong@example.com", "wrongpass");
+
+        Mockito.when(authUseCase.login(Mockito.any(LoginRequestDTO.class)))
+                .thenThrow(new IllegalArgumentException("User not found"));
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("User not found"));
+    }
+
+    @Test
+    void resetPasswordRequest_ShouldReturnSuccessMessage() throws Exception {
+        doNothing().when(authUseCase).resetPasswordRequest("john@example.com");
+
+        mockMvc.perform(post("/reset-password-request")
+                        .param("email", "john@example.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password reset request successful"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    void resetPasswordRequest_ShouldReturnBadRequest_WhenEmailNotFound() throws Exception {
+        Mockito.doThrow(new IllegalArgumentException("No user found with email: john@example.com"))
+                .when(authUseCase).resetPasswordRequest("john@example.com");
+
+        mockMvc.perform(post("/reset-password-request")
+                        .param("email", "john@example.com"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("No user found with email: john@example.com"));
+    }
+
+    @Test
+    void resetPassword_ShouldReturnSuccessMessage() throws Exception {
+        doNothing().when(authUseCase).resetPassword("token123", "newPass");
+
+        mockMvc.perform(post("/reset-password")
+                        .param("token", "token123")
+                        .param("newPassword", "newPass"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password reset successful"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    void resetPassword_ShouldReturnBadRequest_WhenTokenInvalid() throws Exception {
+        Mockito.doThrow(new IllegalArgumentException("Invalid or expired token"))
+                .when(authUseCase).resetPassword("bad-token", "newPass");
+
+        mockMvc.perform(post("/reset-password")
+                        .param("token", "bad-token")
+                        .param("newPassword", "newPass"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Invalid or expired token"));
+    }
+}


### PR DESCRIPTION
This pull request introduces extensive changes to the test suite for the authentication service, focusing on improving test coverage, refining test naming conventions, and adding new tests for password reset functionality. Key updates include the addition of tests for `ResetPasswordServiceImpl`, enhancements to existing tests for `AuthServiceImpl`, `JwtServiceImpl`, and `AuthUseCase`, and the creation of a new controller test for `AuthController`.

### Test Coverage Enhancements:

* **New Tests for Password Reset Service**:
  - Added comprehensive tests for `ResetPasswordServiceImpl`, covering reset link generation, user ID retrieval, email event publishing, and exception handling.

* **Controller Test for Authentication**:
  - Introduced `AuthControllerTest` to validate endpoints for login, password reset requests, and password reset functionality. Includes tests for both successful and failure scenarios.

### Test Naming Improvements:

* **Refactored Test Method Names**:
  - Updated test method names across `AuthServiceImplTest`, `JwtServiceImplTest`, `AuthUseCaseTest`, and `PasswordValidatorTest` to follow a consistent and descriptive naming convention (e.g., `validate_ShouldReturnTrue_WhenPasswordMatches`). [[1]](diffhunk://#diff-3fca30400908219e010e0a45ba92cf7c21a13f10213c03a1e020d776c9a21b66L48-R50) [[2]](diffhunk://#diff-2e7f8684df862e5d9eeba2c7775913601a5e44d4a54f3a0f4d92c44d265306b2L33-R34) [[3]](diffhunk://#diff-6fe8404ad6f8081bed7debd6fdbcef2d9a2dca597d5403e5e6ac7103a5bbc32cL39-R43) [[4]](diffhunk://#diff-c20fbec5af7f6f6832db0f67d865f1a8aa17664b8ad12288b2c3c1909ad30d93L22-R38)

### New Functional Tests:

* **Reset Password Use Case**:
  - Added tests to verify `AuthUseCase` interactions with `ResetPasswordService` for handling password reset requests and token-based password resets.

### Minor Improvements:

* **Assertion Enhancements**:
  - Replaced manual exception handling with `assertThrows` for cleaner and more readable test assertions. [[1]](diffhunk://#diff-3fca30400908219e010e0a45ba92cf7c21a13f10213c03a1e020d776c9a21b66L58-R91) [[2]](diffhunk://#diff-2e7f8684df862e5d9eeba2c7775913601a5e44d4a54f3a0f4d92c44d265306b2L42-R54)

These changes significantly improve the robustness and maintainability of the authentication service's test suite.