### PR TITLE
Add environment specification to build job in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build and analyze
+    environment: prod
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change specifies the `environment` as `prod` for the `build` job.