### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,10 @@ services:
       - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USERNAME}
       - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
       - JWT_SECRET=${JWT_SECRET}
-      - RESET_LINK_PASSENGER=https://gtu-admin.netlify.app/
-      - RESET_LINK_DRIVER=https://gtu-admin.netlify.app/
-      - RESET_LINK_ADMIN=https://gtu-admin.netlify.app/
-      - RESET_LINK_SUPERADMIN=https://gtu-admin.netlify.app/
+      - RESET_LINK_PASSENGER=https://gtu-admin.netlify.app/reset-password
+      - RESET_LINK_DRIVER=https://gtu-admin.netlify.app/reset-password
+      - RESET_LINK_ADMIN=https://gtu-admin.netlify.app/reset-password
+      - RESET_LINK_SUPERADMIN=https://gtu-admin.netlify.app/reset-password
       - SERVER_PORT=0
     volumes:
       - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,10 @@ services:
       - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USERNAME}
       - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
       - JWT_SECRET=${JWT_SECRET}
-      - RESET_LINK_PASSENGER=https://frontend-app.com/reset-password
-      - RESET_LINK_DRIVER=https://frontend-app.com/reset-password
-      - RESET_LINK_ADMIN=https://frontend-app.com/reset-password
-      - RESET_LINK_SUPERADMIN=https://frontend-app.com/reset-password
+      - RESET_LINK_PASSENGER=https://gtu-admin.netlify.app/
+      - RESET_LINK_DRIVER=https://gtu-admin.netlify.app/
+      - RESET_LINK_ADMIN=https://gtu-admin.netlify.app/
+      - RESET_LINK_SUPERADMIN=https://gtu-admin.netlify.app/
       - SERVER_PORT=0
     volumes:
       - ./data:/data

--- a/src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java
+++ b/src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java
@@ -37,8 +37,8 @@ public class ResetPasswordServiceImpl implements ResetPasswordService {
     @Value("${reset.links.superadmin}")
     private String superadminResetLink;
 
-    private final String resetExchange = "reset-password.exchange";
-    private final String resetRoutingKey = "reset-password.routingkey";
+    private static final String resetExchange = "reset-password.exchange";
+    private static final String resetRoutingKey = "reset-password.routingkey";
 
     public ResetPasswordServiceImpl(UserClient userClient, PassengerClient passengerClient,
                                    ResetTokenRepository resetTokenRepository, RabbitTemplate rabbitTemplate,

--- a/src/main/java/com/gtu/auth_service/application/usecase/AuthUseCase.java
+++ b/src/main/java/com/gtu/auth_service/application/usecase/AuthUseCase.java
@@ -16,13 +16,13 @@ public class AuthUseCase {
     private final AuthService authService;
     private final JwtService jwtService;
     private final ResetPasswordService resetPasswordService;
-    private final PasswordValidator PasswordValidator;
+    private final PasswordValidator passwordValidator;
 
-    public AuthUseCase(AuthService authService, JwtService jwtService, ResetPasswordService resetPasswordService, PasswordValidator PasswordValidator) {
+    public AuthUseCase(AuthService authService, JwtService jwtService, ResetPasswordService resetPasswordService, PasswordValidator passwordValidator) {
         this.authService = authService;
         this.jwtService = jwtService;
         this.resetPasswordService = resetPasswordService;
-        this.PasswordValidator = PasswordValidator;
+        this.passwordValidator = passwordValidator;
     }
 
     public LoginResponseDTO login(LoginRequestDTO request) {
@@ -30,7 +30,7 @@ public class AuthUseCase {
         if (user == null) {
             throw new IllegalArgumentException("User not found");
         }
-        if (!PasswordValidator.validate(request.password(), user.password())) {
+        if (!passwordValidator.validate(request.password(), user.password())) {
             throw new IllegalArgumentException("Invalid password");
         }
         String token = jwtService.generateToken(user);
@@ -48,7 +48,7 @@ public class AuthUseCase {
         if (passenger == null) {
             throw new IllegalArgumentException("Passenger not found");
         }
-        if (!PasswordValidator.validate(request.password(), passenger.password())) {
+        if (!passwordValidator.validate(request.password(), passenger.password())) {
             throw new IllegalArgumentException("Invalid password");
         }
         String token = jwtService.generateToken(passenger);

--- a/src/test/java/com/gtu/auth_service/AuthServiceApplicationTests.java
+++ b/src/test/java/com/gtu/auth_service/AuthServiceApplicationTests.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.TestPropertySource;
 class AuthServiceApplicationTests {
     @Test
     void contextLoads() {
+        // This test ensures that the Spring context is loaded correctly.
     }
 }
 

--- a/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
+++ b/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-public class AuthUseCaseTest {
+class AuthUseCaseTest {
     @Mock
     private AuthServiceImpl authService;
 

--- a/src/test/java/com/gtu/auth_service/infrastructure/ResetTokenRepositoryImplTest.java
+++ b/src/test/java/com/gtu/auth_service/infrastructure/ResetTokenRepositoryImplTest.java
@@ -70,7 +70,7 @@ class ResetTokenRepositoryImplTest {
     }
 
     @Test
-    void save_ShouldInvokeJpaRepositorySave() {
+    void save_ShouldInvoke_JpaRepositorySave() {
         ResetToken domainToken = new ResetToken();
         domainToken.setId(3L);
         domainToken.setToken("token789");


### PR DESCRIPTION
This pull request updates environment variables in the `docker-compose.yml` file to reflect a change in the URLs used for reset links across different user roles.

Environment variable updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L17-R20): Changed the reset link URLs for `PASSENGER`, `DRIVER`, `ADMIN`, and `SUPERADMIN` from `https://frontend-app.com/reset-password` to `https://gtu-admin.netlify.app/`.