### PR TITLE
Refactor ResetPasswordServiceImpl and AuthUseCase for consistency

### DIFF
--- a/src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java
+++ b/src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java
@@ -37,8 +37,8 @@ public class ResetPasswordServiceImpl implements ResetPasswordService {
     @Value("${reset.links.superadmin}")
     private String superadminResetLink;
 
-    private final String resetExchange = "reset-password.exchange";
-    private final String resetRoutingKey = "reset-password.routingkey";
+    private static final String resetExchange = "reset-password.exchange";
+    private static final String resetRoutingKey = "reset-password.routingkey";
 
     public ResetPasswordServiceImpl(UserClient userClient, PassengerClient passengerClient,
                                    ResetTokenRepository resetTokenRepository, RabbitTemplate rabbitTemplate,

--- a/src/main/java/com/gtu/auth_service/application/usecase/AuthUseCase.java
+++ b/src/main/java/com/gtu/auth_service/application/usecase/AuthUseCase.java
@@ -16,13 +16,13 @@ public class AuthUseCase {
     private final AuthService authService;
     private final JwtService jwtService;
     private final ResetPasswordService resetPasswordService;
-    private final PasswordValidator PasswordValidator;
+    private final PasswordValidator passwordValidator;
 
-    public AuthUseCase(AuthService authService, JwtService jwtService, ResetPasswordService resetPasswordService, PasswordValidator PasswordValidator) {
+    public AuthUseCase(AuthService authService, JwtService jwtService, ResetPasswordService resetPasswordService, PasswordValidator passwordValidator) {
         this.authService = authService;
         this.jwtService = jwtService;
         this.resetPasswordService = resetPasswordService;
-        this.PasswordValidator = PasswordValidator;
+        this.passwordValidator = passwordValidator;
     }
 
     public LoginResponseDTO login(LoginRequestDTO request) {
@@ -30,7 +30,7 @@ public class AuthUseCase {
         if (user == null) {
             throw new IllegalArgumentException("User not found");
         }
-        if (!PasswordValidator.validate(request.password(), user.password())) {
+        if (!passwordValidator.validate(request.password(), user.password())) {
             throw new IllegalArgumentException("Invalid password");
         }
         String token = jwtService.generateToken(user);
@@ -48,7 +48,7 @@ public class AuthUseCase {
         if (passenger == null) {
             throw new IllegalArgumentException("Passenger not found");
         }
-        if (!PasswordValidator.validate(request.password(), passenger.password())) {
+        if (!passwordValidator.validate(request.password(), passenger.password())) {
             throw new IllegalArgumentException("Invalid password");
         }
         String token = jwtService.generateToken(passenger);

--- a/src/test/java/com/gtu/auth_service/AuthServiceApplicationTests.java
+++ b/src/test/java/com/gtu/auth_service/AuthServiceApplicationTests.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.TestPropertySource;
 class AuthServiceApplicationTests {
     @Test
     void contextLoads() {
+        // This test ensures that the Spring context is loaded correctly.
     }
 }
 

--- a/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
+++ b/src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-public class AuthUseCaseTest {
+class AuthUseCaseTest {
     @Mock
     private AuthServiceImpl authService;
 

--- a/src/test/java/com/gtu/auth_service/infrastructure/ResetTokenRepositoryImplTest.java
+++ b/src/test/java/com/gtu/auth_service/infrastructure/ResetTokenRepositoryImplTest.java
@@ -70,7 +70,7 @@ class ResetTokenRepositoryImplTest {
     }
 
     @Test
-    void save_ShouldInvokeJpaRepositorySave() {
+    void save_ShouldInvoke_JpaRepositorySave() {
         ResetToken domainToken = new ResetToken();
         domainToken.setId(3L);
         domainToken.setToken("token789");


### PR DESCRIPTION
This pull request includes several changes across the codebase, focusing on improving code consistency, readability, and test structure. The most notable changes involve fixing naming conventions, adjusting field modifiers, and refining test classes.

### Code consistency and readability improvements:

* [`src/main/java/com/gtu/auth_service/application/service/ResetPasswordServiceImpl.java`](diffhunk://#diff-f19a6fcfa99d1e0d96a56c6170a816a89cc0217de84c01a5c5c7c9753924b9d8L40-R41): Changed `resetExchange` and `resetRoutingKey` fields from `private` to `static final` to align with best practices for constants.
* [`src/main/java/com/gtu/auth_service/application/usecase/AuthUseCase.java`](diffhunk://#diff-2801800439f3526ff11092c56f0036d9b12ca0a466ed7b7f415fef17a6f6c55bL19-R33): Fixed naming convention for the `PasswordValidator` field and its occurrences, changing it to `passwordValidator` for consistency. [[1]](diffhunk://#diff-2801800439f3526ff11092c56f0036d9b12ca0a466ed7b7f415fef17a6f6c55bL19-R33) [[2]](diffhunk://#diff-2801800439f3526ff11092c56f0036d9b12ca0a466ed7b7f415fef17a6f6c55bL51-R51)

### Test structure refinements:

* [`src/test/java/com/gtu/auth_service/AuthServiceApplicationTests.java`](diffhunk://#diff-2602a707638fbe1836123301462349437b6ea8f4f64cb60ec79cfa57fab17e50R21): Added a comment to clarify the purpose of the `contextLoads` test.
* [`src/test/java/com/gtu/auth_service/application/usecase/AuthUseCaseTest.java`](diffhunk://#diff-6fe8404ad6f8081bed7debd6fdbcef2d9a2dca597d5403e5e6ac7103a5bbc32cL22-R22): Changed the test class declaration from `public` to package-private for better encapsulation.
* [`src/test/java/com/gtu/auth_service/infrastructure/ResetTokenRepositoryImplTest.java`](diffhunk://#diff-a1d12aed9bad013c42018ce2352c8df9600e4273e8ea6abf23c90cc4aefecd56L73-R73): Updated the test method name to follow a consistent naming convention (`save_ShouldInvoke_JpaRepositorySave`).