### PR TITLE
Update/reset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,7 @@ services:
       - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USERNAME}
       - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
       - JWT_SECRET=${JWT_SECRET}
-      - RESET_LINK_PASSENGER=https://gtu-admin.netlify.app/reset-password
-      - RESET_LINK_DRIVER=https://gtu-admin.netlify.app/reset-password
-      - RESET_LINK_ADMIN=https://gtu-admin.netlify.app/reset-password
-      - RESET_LINK_SUPERADMIN=https://gtu-admin.netlify.app/reset-password
+      - RESET_LINKS_BASE=https://gtu-admin.netlify.app/reset-password
       - SERVER_PORT=0
     volumes:
       - ./data:/data

--- a/src/main/java/com/gtu/auth_service/application/dto/ResetPasswordDTO.java
+++ b/src/main/java/com/gtu/auth_service/application/dto/ResetPasswordDTO.java
@@ -1,0 +1,13 @@
+package com.gtu.auth_service.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResetPasswordDTO {
+    private String token;
+    private String newPassword;
+}

--- a/src/main/java/com/gtu/auth_service/application/dto/ResetPasswordRequestDTO.java
+++ b/src/main/java/com/gtu/auth_service/application/dto/ResetPasswordRequestDTO.java
@@ -1,0 +1,12 @@
+package com.gtu.auth_service.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResetPasswordRequestDTO {
+    private String email;
+}

--- a/src/main/java/com/gtu/auth_service/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/gtu/auth_service/application/service/AuthServiceImpl.java
@@ -82,7 +82,7 @@ public class AuthServiceImpl implements AuthService {
         if (newPassenger == null) throw new  IllegalArgumentException("Failed to register passenger");
 
         return new AuthUser(
-                null,
+                newPassenger.getId(),
                 newPassenger.getName(),
                 newPassenger.getEmail(),
                 newPassenger.getPassword(),

--- a/src/main/java/com/gtu/auth_service/domain/exception/GeneralException.java
+++ b/src/main/java/com/gtu/auth_service/domain/exception/GeneralException.java
@@ -1,0 +1,22 @@
+package com.gtu.auth_service.domain.exception;
+
+public class GeneralException extends RuntimeException {
+    private final int statusCode;
+    private final String message;
+
+    public GeneralException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+    
+}

--- a/src/main/java/com/gtu/auth_service/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gtu/auth_service/presentation/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.gtu.auth_service.presentation.exception;
 
 import com.gtu.auth_service.application.dto.ErrorResponseDTO;
+import com.gtu.auth_service.domain.exception.GeneralException;
 import com.gtu.auth_service.infrastructure.logs.LogPublisher;
 
 import feign.FeignException;
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -81,6 +84,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleFeignNotFound(FeignException.NotFound ex) {
         ErrorResponseDTO error = new ErrorResponseDTO("User not found in remote service", HttpStatus.NOT_FOUND.value(), "Not Found");
         return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ErrorResponseDTO> handleHttpException(GeneralException ex, HttpServletRequest request) {
+        ErrorResponseDTO response = new ErrorResponseDTO(
+                ex.getMessage(),
+                ex.getStatusCode(),
+                HttpStatus.valueOf(ex.getStatusCode()).getReasonPhrase()
+        );
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatusCode()));
     }
 
 }

--- a/src/main/java/com/gtu/auth_service/presentation/rest/AuthController.java
+++ b/src/main/java/com/gtu/auth_service/presentation/rest/AuthController.java
@@ -3,6 +3,8 @@ package com.gtu.auth_service.presentation.rest;
 import com.gtu.auth_service.application.dto.LoginRequestDTO;
 import com.gtu.auth_service.application.dto.LoginResponseDTO;
 import com.gtu.auth_service.application.dto.RegisterRequestDTO;
+import com.gtu.auth_service.application.dto.ResetPasswordDTO;
+import com.gtu.auth_service.application.dto.ResetPasswordRequestDTO;
 import com.gtu.auth_service.application.usecase.AuthUseCase;
 import com.gtu.auth_service.application.dto.ResponseDTO;
 import jakarta.validation.Valid;
@@ -33,16 +35,17 @@ public class AuthController {
     }
 
     @PostMapping("/reset-password-request")
-    public ResponseEntity<ResponseDTO<Void>> resetPasswordRequest(@RequestParam String email) {
-        authUseCase.resetPasswordRequest(email);
+    public ResponseEntity<ResponseDTO<Void>> resetPasswordRequest(@RequestBody ResetPasswordRequestDTO request) {
+        authUseCase.resetPasswordRequest(request.getEmail());
         return ResponseEntity.ok(new ResponseDTO<>("Password reset request successful", null, 200));
     }
 
     @PostMapping("/reset-password")
-    public ResponseEntity<ResponseDTO<Void>> resetPassword(@RequestParam String token, @RequestParam String newPassword) {
-        authUseCase.resetPassword(token, newPassword);
+    public ResponseEntity<ResponseDTO<Void>> resetPassword(@RequestBody ResetPasswordDTO request) {
+        authUseCase.resetPassword(request.getToken(), request.getNewPassword());
         return ResponseEntity.ok(new ResponseDTO<>("Password reset successful", null, 200));
     }
+
 
     @PostMapping("/register")
     public ResponseEntity<ResponseDTO<LoginResponseDTO>> registerPassenger(@Valid @RequestBody RegisterRequestDTO request) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,9 +29,6 @@ spring.rabbitmq.password=${RABBITMQ_PASSWORD}
 rabbitmq.exchange.reset=reset-password.exchange
 rabbitmq.routingkey.reset=reset-password.routingkey
 
-reset.links.passenger=${RESET_LINK_PASSENGER}
-reset.links.driver=${RESET_LINK_DRIVER}
-reset.links.admin=${RESET_LINK_ADMIN}
-reset.links.superadmin=${RESET_LINK_SUPERADMIN}
+reset.links.base=${RESET_LINKS_BASE}
 
 

--- a/src/test/java/com/gtu/auth_service/AuthServiceApplicationTests.java
+++ b/src/test/java/com/gtu/auth_service/AuthServiceApplicationTests.java
@@ -9,10 +9,7 @@ import org.springframework.test.context.TestPropertySource;
     "spring.datasource.driver-class-name=org.h2.Driver",
     "spring.datasource.username=sa",
     "spring.datasource.password=",
-    "reset.links.passenger=http://localhost:8080/reset-password",
-    "reset.links.driver=http://localhost:8080/reset-password",
-    "reset.links.admin=http://localhost:8080/reset-password",
-    "reset.links.superadmin=http://localhost:8080/reset-password",
+    "reset.links.base=http://localhost:8080/reset-password",
 })
 @TestPropertySource(properties = "JWT_SECRET=test-secret")
 class AuthServiceApplicationTests {

--- a/src/test/java/com/gtu/auth_service/application/service/ResetPasswordServiceImplTest.java
+++ b/src/test/java/com/gtu/auth_service/application/service/ResetPasswordServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.gtu.auth_service.application.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gtu.auth_service.domain.exception.GeneralException;
 import com.gtu.auth_service.domain.model.ResetToken;
 import com.gtu.auth_service.domain.model.Role;
 import com.gtu.auth_service.domain.repository.ResetTokenRepository;
@@ -8,19 +9,22 @@ import com.gtu.auth_service.infrastructure.client.PassengerClient;
 import com.gtu.auth_service.infrastructure.client.UserClient;
 import com.gtu.auth_service.infrastructure.client.dto.UserServiceResponse;
 import com.gtu.auth_service.infrastructure.logs.LogPublisher;
-
+import com.gtu.auth_service.infrastructure.messaging.event.ResetPasswordEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class ResetPasswordServiceImplTest {
@@ -37,18 +41,18 @@ class ResetPasswordServiceImplTest {
     @Mock
     private RabbitTemplate rabbitTemplate;
 
-    @InjectMocks
-    private ResetPasswordServiceImpl resetPasswordService;
-
+    @Mock
     private ObjectMapper objectMapper;
 
     @Mock
     private LogPublisher logPublisher;
 
+    @InjectMocks
+    private ResetPasswordServiceImpl resetPasswordService;
+
     @BeforeEach
     void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
-        objectMapper = new ObjectMapper();
         resetPasswordService = new ResetPasswordServiceImpl(
                 userClient,
                 passengerClient,
@@ -57,11 +61,7 @@ class ResetPasswordServiceImplTest {
                 objectMapper,
                 logPublisher
         );
-
-        setField("passengerResetLink", "http://reset/passenger");
-        setField("driverResetLink", "http://reset/driver");
-        setField("adminResetLink", "http://reset/admin");
-        setField("superadminResetLink", "http://reset/superadmin");
+        setField("resetLinkBase", "http://reset/base"); 
     }
 
     private void setField(String name, String value) throws Exception {
@@ -71,213 +71,164 @@ class ResetPasswordServiceImplTest {
     }
 
     @Test
-    void generateResetLink_ShouldReturnDriverResetLink() {
-        UserServiceResponse user = new UserServiceResponse(1L, "John", "john@example.com", "pass", "DRIVER");
-        String token = UUID.randomUUID().toString();
+    void requestPasswordReset_shouldSucceedForUser() throws Exception {
+        UserServiceResponse user = new UserServiceResponse(1L, "user@gtu.com", null, null, null);
+        when(userClient.getUserByEmail("user@gtu.com")).thenReturn(user);
+        when(resetTokenRepository.findByEmailAndUsedFalse("user@gtu.com")).thenReturn(Optional.empty());
+        when(objectMapper.writeValueAsString(any(ResetPasswordEvent.class))).thenReturn("{\"test\":\"json\"}");
 
-        String result = resetPasswordService.generateResetLink(user, token);
+        resetPasswordService.requestPasswordReset("user@gtu.com");
 
-        assertTrue(result.startsWith("http://reset/driver"));
-        assertTrue(result.contains(token));
+        verify(resetTokenRepository).save(any(ResetToken.class));
+        verify(rabbitTemplate).convertAndSend(anyString(), anyString(), anyString());
+        verify(logPublisher).sendLog(anyString(), eq("auth-service"), eq("INFO"),eq("Reset email event sent successfully"),anyMap());
     }
 
     @Test
-    void generateResetLink_ShouldReturnPassengerLink_WhenRoleIsNull() {
-        UserServiceResponse user = new UserServiceResponse(1L, "Jane", "jane@example.com", "pass", null);
-        String token = "abc123";
+    void requestPasswordReset_shouldSucceedForPassenger() throws Exception {
+        UserServiceResponse user = new UserServiceResponse(null, "passenger@gtu.com", null, null, null);
+        UserServiceResponse passenger = new UserServiceResponse(2L, "passenger@gtu.com", null, null, null);
+        when(userClient.getUserByEmail("passenger@gtu.com")).thenReturn(user);
+        when(passengerClient.getPassengerByEmail("passenger@gtu.com")).thenReturn(passenger);
+        when(resetTokenRepository.findByEmailAndUsedFalse("passenger@gtu.com")).thenReturn(Optional.empty());
+        when(objectMapper.writeValueAsString(any(ResetPasswordEvent.class))).thenReturn("{\"test\":\"json\"}");
 
-        String result = resetPasswordService.generateResetLink(user, token);
+        resetPasswordService.requestPasswordReset("passenger@gtu.com");
 
-        assertEquals("http://reset/passenger?token=abc123", result);
+        verify(passengerClient).getPassengerByEmail("passenger@gtu.com");
+        verify(resetTokenRepository).save(any(ResetToken.class));
+        verify(rabbitTemplate).convertAndSend(anyString(), anyString(), anyString());
     }
 
     @Test
-    void generateResetLink_ShouldReturnAdminResetLink() {
-        UserServiceResponse user = new UserServiceResponse(1L, "Admin", "admin@example.com", "pass", "ADMIN");
-        String token = "def456";
+    void requestPasswordReset_shouldThrowGeneralExceptionWhenTokenPending() {
+        UserServiceResponse user = new UserServiceResponse(1L, "user@gtu.com", null, null, null);
+        when(userClient.getUserByEmail("user@gtu.com")).thenReturn(user);
+        when(resetTokenRepository.findByEmailAndUsedFalse("user@gtu.com")).thenReturn(Optional.of(new ResetToken()));
 
-        String result = resetPasswordService.generateResetLink(user, token);
-
-        assertEquals("http://reset/admin?token=def456", result);
+        GeneralException exception = assertThrows(GeneralException.class, () ->
+            resetPasswordService.requestPasswordReset("user@gtu.com"));
+        assertEquals("A reset token is already pending for this email: user@gtu.com", exception.getMessage());
+        assertEquals(409, exception.getStatusCode());
     }
 
     @Test
-    void generateResetLink_ShouldReturnSuperadminResetLink() {
-        UserServiceResponse user = new UserServiceResponse(1L, "Super", "super@example.com", "pass", "SUPERADMIN");
-        String token = "ghi789";
+    void generateResetLink_shouldReturnBaseLinkWithToken() {
+        UserServiceResponse user = new UserServiceResponse(1L, "user@gtu.com", null, null, null);
+        String token = "test-token";
 
-        String result = resetPasswordService.generateResetLink(user, token);
+        String resetLink = resetPasswordService.generateResetLink(user, token);
 
-        assertEquals("http://reset/superadmin?token=ghi789", result);
+        assertEquals("http://reset/base?token=test-token", resetLink);
     }
 
     @Test
-    void generateResetLink_ShouldThrowException_ForInvalidRole() {
-        UserServiceResponse user = new UserServiceResponse(1L, "Fake", "fake@example.com", "pass", "HACKER");
+    void sendResetEmailEvent_shouldSucceedWhenValid() throws Exception {
+        when(objectMapper.writeValueAsString(any(ResetPasswordEvent.class))).thenReturn("{\"test\":\"json\"}");
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                resetPasswordService.generateResetLink(user, "token123"));
+        resetPasswordService.sendResetEmailEvent("user@gtu.com", Role.ADMIN, "http://reset/base?token=test");
 
-        assertEquals("Unsupported role: HACKER", ex.getMessage());
+        verify(rabbitTemplate).convertAndSend("reset-password.exchange", "reset-password.routingkey", "{\"test\":\"json\"}");
+        verify(logPublisher).sendLog(anyString(), eq("auth-service"), eq("INFO"), anyString(), anyMap());
     }
 
     @Test
-    void getUserIdByEmail_ShouldReturnId_WhenUserExists() {
-        UserServiceResponse user = new UserServiceResponse(10L, "X", "x@example.com", "pass", "ADMIN");
-        when(userClient.getUserByEmail("x@example.com")).thenReturn(user);
+    void resetPassword_shouldSucceedForUser() throws Exception {
+        ResetToken token = new ResetToken();
+        token.setToken("valid-token");
+        token.setEmail("user@gtu.com");
+        token.setExpiryDate(LocalDateTime.now().plusMinutes(30));
+        token.setUsed(false);
+        when(resetTokenRepository.findByToken("valid-token")).thenReturn(Optional.of(token));
+        when(userClient.getUserByEmail("user@gtu.com")).thenReturn(new UserServiceResponse(1L, "user@gtu.com", null, null, null));
+        doNothing().when(userClient).resetPassword(1L, "NewPass1");
 
-        Long result = resetPasswordService.getUserIdByEmail("x@example.com");
+        resetPasswordService.resetPassword("valid-token", "NewPass1");
 
-        assertEquals(10L, result);
+        verify(userClient).resetPassword(1L, "NewPass1");
+        verify(resetTokenRepository).save(token);
     }
 
     @Test
-    void getUserIdByEmail_ShouldReturnNull_WhenNotFound() {
-        when(userClient.getUserByEmail("x@example.com")).thenThrow(RuntimeException.class);
+    void resetPassword_shouldSucceedForPassenger() throws Exception {
+        ResetToken token = new ResetToken();
+        token.setToken("valid-token");
+        token.setEmail("passenger@gtu.com");
+        token.setExpiryDate(LocalDateTime.now().plusMinutes(30));
+        token.setUsed(false);
+        when(resetTokenRepository.findByToken("valid-token")).thenReturn(Optional.of(token));
+        when(userClient.getUserByEmail("passenger@gtu.com")).thenReturn(new UserServiceResponse(null, "passenger@gtu.com", null, null, null));
+        when(passengerClient.getPassengerByEmail("passenger@gtu.com")).thenReturn(new UserServiceResponse(2L, "passenger@gtu.com", null, null, null));
+        doNothing().when(passengerClient).resetPassword(2L, "NewPass1");
 
-        Long result = resetPasswordService.getUserIdByEmail("x@example.com");
+        resetPasswordService.resetPassword("valid-token", "NewPass1");
 
-        assertNull(result);
+        verify(passengerClient).resetPassword(2L, "NewPass1");
+        verify(resetTokenRepository).save(token);
     }
 
     @Test
-    void sendResetEmailEvent_ShouldPublishMessage() {
-        doNothing().when(rabbitTemplate).convertAndSend(anyString(), anyString(), anyString());
+    void resetPassword_shouldThrowExceptionWhenTokenInvalid() {
+        when(resetTokenRepository.findByToken("invalid-token")).thenReturn(Optional.empty());
 
-        assertDoesNotThrow(() ->
-                resetPasswordService.sendResetEmailEvent("user@example.com", Role.ADMIN, "http://reset/admin?token=abc"));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            resetPasswordService.resetPassword("invalid-token", "NewPass1"));
+        assertEquals("Invalid or expired token", exception.getMessage());
+        verify(logPublisher).sendLog(anyString(), eq("auth-service"), eq("ERROR"), anyString(), anyMap());
     }
 
     @Test
-    void sendResetEmailEvent_ShouldThrowException_WhenObjectMapperFails() throws Exception {
-        ResetPasswordServiceImpl service = new ResetPasswordServiceImpl(
-                userClient, passengerClient, resetTokenRepository, rabbitTemplate, mock(ObjectMapper.class), logPublisher
-        );
-        setFieldOnInstance(service, "adminResetLink", "http://reset/admin");
-        setFieldOnInstance(service, "driverResetLink", "http://reset/driver");
-        setFieldOnInstance(service, "passengerResetLink", "http://reset/passenger");
-        setFieldOnInstance(service, "superadminResetLink", "http://reset/superadmin");
+    void resetPassword_shouldThrowExceptionWhenTokenExpired() {
+        ResetToken token = new ResetToken();
+        token.setToken("expired-token");
+        token.setExpiryDate(LocalDateTime.now().minusMinutes(30));
+        token.setUsed(false);
+        when(resetTokenRepository.findByToken("expired-token")).thenReturn(Optional.of(token));
 
-        ObjectMapper failingMapper = mock(ObjectMapper.class);
-        when(failingMapper.writeValueAsString(any())).thenThrow(new RuntimeException("Mapper error"));
-
-        var serviceWithFailingMapper = new ResetPasswordServiceImpl(
-                userClient, passengerClient, resetTokenRepository, rabbitTemplate, failingMapper, logPublisher);
-
-        setFieldOnInstance(serviceWithFailingMapper, "adminResetLink", "http://reset/admin");
-
-        RuntimeException ex = assertThrows(RuntimeException.class, () ->
-                serviceWithFailingMapper.sendResetEmailEvent("x", Role.ADMIN, "http://link"));
-
-        assertTrue(ex.getMessage().contains("Failed to send reset email event"));
-    }
-
-    private void setFieldOnInstance(Object target, String fieldName, String value) throws Exception {
-        var field = ResetPasswordServiceImpl.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(target, value);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            resetPasswordService.resetPassword("expired-token", "NewPass1"));
+        assertEquals("Token has expired or already used", exception.getMessage());
     }
 
     @Test
-    void requestPasswordReset_ShouldSaveToken_WhenUserExists() {
-        UserServiceResponse user = new UserServiceResponse(1L, "John", "john@example.com", "pass", "DRIVER");
-        when(userClient.getUserByEmail("john@example.com")).thenReturn(user);
-        when(resetTokenRepository.findByEmailAndUsedFalse("john@example.com")).thenReturn(Optional.empty());
-        doNothing().when(rabbitTemplate).convertAndSend(anyString(), anyString(), anyString());
+    void getUserIdByEmail_shouldReturnIdWhenFound() {
+        UserServiceResponse user = new UserServiceResponse(1L, "user@gtu.com", null, null, null);
+        when(userClient.getUserByEmail("user@gtu.com")).thenReturn(user);
 
-        assertDoesNotThrow(() -> resetPasswordService.requestPasswordReset("john@example.com"));
+        Long id = resetPasswordService.getUserIdByEmail("user@gtu.com");
 
-        verify(resetTokenRepository, times(1)).save(any());
+        assertEquals(1L, id);
+        verify(userClient).getUserByEmail("user@gtu.com");
     }
 
     @Test
-    void requestPasswordReset_ShouldThrowException_WhenTokenExists() {
-        UserServiceResponse user = new UserServiceResponse(1L, "John", "john@example.com", "pass", "DRIVER");
-        when(userClient.getUserByEmail("john@example.com")).thenReturn(user);
-        when(resetTokenRepository.findByEmailAndUsedFalse("john@example.com"))
-            .thenReturn(Optional.of(new ResetToken()));
+    void getUserIdByEmail_shouldReturnNullWhenNotFound() {
+        when(userClient.getUserByEmail("notfound@gtu.com")).thenThrow(new RuntimeException("Not found"));
 
-        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
-                resetPasswordService.requestPasswordReset("john@example.com"));
+        Long id = resetPasswordService.getUserIdByEmail("notfound@gtu.com");
 
-        assertTrue(ex.getMessage().contains("A reset token is already pending"));
+        assertNull(id);
+        verify(userClient).getUserByEmail("notfound@gtu.com");
     }
 
     @Test
-    void requestPasswordReset_ShouldThrowException_WhenSaveFails() {
-        UserServiceResponse user = new UserServiceResponse(1L, "John", "john@example.com", "pass", "DRIVER");
-        when(userClient.getUserByEmail("john@example.com")).thenReturn(user);
-        when(resetTokenRepository.findByEmailAndUsedFalse("john@example.com")).thenReturn(Optional.empty());
-        doThrow(new RuntimeException("Save failed")).when(resetTokenRepository).save(any());
+    void getPassengerIdByEmail_shouldReturnIdWhenFound() {
+        UserServiceResponse passenger = new UserServiceResponse(2L, "passenger@gtu.com", null, null, null);
+        when(passengerClient.getPassengerByEmail("passenger@gtu.com")).thenReturn(passenger);
 
-        assertThrows(RuntimeException.class, () -> resetPasswordService.requestPasswordReset("john@example.com"));
+        Long id = resetPasswordService.getPassengerIdByEmail("passenger@gtu.com");
+
+        assertEquals(2L, id);
+        verify(passengerClient).getPassengerByEmail("passenger@gtu.com");
     }
 
     @Test
-    void resetPassword_ShouldCallUserClient_WhenUserExists() {
-        ResetToken resetToken = new ResetToken(1L, "token123", "john@example.com", LocalDateTime.now().plusMinutes(10), false);
-        when(resetTokenRepository.findByToken("token123")).thenReturn(Optional.of(resetToken));
-        when(userClient.getUserByEmail("john@example.com")).thenReturn(new UserServiceResponse(1L, "John", "john@example.com", "pass", "DRIVER"));
+    void getPassengerIdByEmail_shouldReturnNullWhenNotFound() {
+        when(passengerClient.getPassengerByEmail("notfound@gtu.com")).thenThrow(new RuntimeException("Not found"));
 
-        resetPasswordService.resetPassword("token123", "newPass");
+        Long id = resetPasswordService.getPassengerIdByEmail("notfound@gtu.com");
 
-        verify(userClient, times(1)).resetPassword(1L, "newPass");
-        verify(resetTokenRepository, times(1)).save(any());
+        assertNull(id);
+        verify(passengerClient).getPassengerByEmail("notfound@gtu.com");
     }
-
-    @Test
-    void resetPassword_ShouldThrowException_WhenNoUserOrPassengerFound() {
-        ResetToken resetToken = new ResetToken(1L, "token123", "nonexistent@example.com", LocalDateTime.now().plusMinutes(10), false);
-        when(resetTokenRepository.findByToken("token123")).thenReturn(Optional.of(resetToken));
-        when(userClient.getUserByEmail("nonexistent@example.com")).thenThrow(RuntimeException.class);
-        when(passengerClient.getPassengerByEmail("nonexistent@example.com")).thenThrow(RuntimeException.class);
-
-        assertThrows(IllegalArgumentException.class, () ->
-                resetPasswordService.resetPassword("token123", "newPass"));
-    }
-
-    @Test
-    void resetPassword_ShouldThrowException_WhenTokenExpired() {
-        ResetToken token = new ResetToken(1L, "expiredToken", "user@example.com",
-                LocalDateTime.now().minusMinutes(1), false);
-        when(resetTokenRepository.findByToken("expiredToken")).thenReturn(Optional.of(token));
-
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                resetPasswordService.resetPassword("expiredToken", "newPass"));
-        
-        assertTrue(ex.getMessage().contains("Token has expired"));
-    }
-
-    @Test
-    void resetPassword_ShouldThrowException_WhenTokenUsed() {
-        ResetToken token = new ResetToken(1L, "usedToken", "user@example.com",
-                LocalDateTime.now().plusMinutes(5), true);
-        when(resetTokenRepository.findByToken("usedToken")).thenReturn(Optional.of(token));
-
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                resetPasswordService.resetPassword("usedToken", "newPass"));
-
-        assertTrue(ex.getMessage().contains("Token has expired or already used"));
-    }
-
-    @Test
-    void getPassengerIdByEmail_ShouldReturnId_WhenPassengerExists() {
-        UserServiceResponse passenger = new UserServiceResponse(5L, "Maria", "maria@example.com", "pass", null);
-        when(passengerClient.getPassengerByEmail("maria@example.com")).thenReturn(passenger);
-
-        Long result = resetPasswordService.getPassengerIdByEmail("maria@example.com");
-
-        assertEquals(5L, result);
-    }
-
-    @Test
-    void getPassengerIdByEmail_ShouldReturnNull_WhenExceptionOccurs() {
-        when(passengerClient.getPassengerByEmail("fail@example.com")).thenThrow(new RuntimeException("boom"));
-
-        Long result = resetPasswordService.getPassengerIdByEmail("fail@example.com");
-
-        assertNull(result);
-    }
-
-    
 }

--- a/src/test/java/com/gtu/auth_service/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/com/gtu/auth_service/presentation/rest/AuthControllerTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Map;
+
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
 
@@ -88,7 +90,8 @@ class AuthControllerTest {
                 doNothing().when(authUseCase).resetPasswordRequest("john@example.com");
 
                 mockMvc.perform(post("/reset-password-request")
-                                .param("email", "john@example.com"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString("john@example.com")))
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$.message").value("Password reset request successful"))
                                 .andExpect(jsonPath("$.data").doesNotExist());
@@ -100,7 +103,8 @@ class AuthControllerTest {
                                 .when(authUseCase).resetPasswordRequest("john@example.com");
 
                 mockMvc.perform(post("/reset-password-request")
-                                .param("email", "john@example.com"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString("john@example.com")))
                                 .andExpect(status().isUnauthorized())
                                 .andExpect(jsonPath("$.status").value(401))
                                 .andExpect(jsonPath("$.error").value("Unauthorized"))
@@ -112,8 +116,8 @@ class AuthControllerTest {
                 doNothing().when(authUseCase).resetPassword("token123", "newPass");
 
                 mockMvc.perform(post("/reset-password")
-                                .param("token", "token123")
-                                .param("newPassword", "newPass"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(Map.of("token", "token123", "newPassword", "newPass"))))
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$.message").value("Password reset successful"))
                                 .andExpect(jsonPath("$.data").doesNotExist());
@@ -125,8 +129,8 @@ class AuthControllerTest {
                                 .when(authUseCase).resetPassword("bad-token", "newPass");
 
                 mockMvc.perform(post("/reset-password")
-                                .param("token", "bad-token")
-                                .param("newPassword", "newPass"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(Map.of("token", "bad-token", "newPassword", "newPass"))))
                                 .andExpect(status().isUnauthorized())
                                 .andExpect(jsonPath("$.status").value(401))
                                 .andExpect(jsonPath("$.error").value("Unauthorized"))


### PR DESCRIPTION
This pull request introduces several changes aimed at simplifying the password reset functionality, improving error handling, and refactoring code for better maintainability. The key updates include consolidating reset link configurations, introducing new DTOs for password reset requests, enhancing exception handling with a custom exception, and updating test cases to align with the refactored implementation.

### Refactoring for reset link management:
* Consolidated reset link environment variables into a single `RESET_LINKS_BASE` configuration in `docker-compose.yml` and `application.properties`. This replaces individual reset links for different roles (e.g., passenger, driver, admin, superadmin). (`docker-compose.yml` - [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L17-R17) `application.properties` - [[2]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L32-R32)
* Updated `ResetPasswordServiceImpl` to use the unified `resetLinkBase` configuration for generating reset links, simplifying the `generateResetLink` method. (`ResetPasswordServiceImpl.java` - [[1]](diffhunk://#diff-f19a6fcfa99d1e0d96a56c6170a816a89cc0217de84c01a5c5c7c9753924b9d8L32-R34) [[2]](diffhunk://#diff-f19a6fcfa99d1e0d96a56c6170a816a89cc0217de84c01a5c5c7c9753924b9d8L92-R100)

### Improved error handling:
* Introduced a new `GeneralException` class to standardize error handling with HTTP status codes and error messages. (`GeneralException.java` - [src/main/java/com/gtu/auth_service/domain/exception/GeneralException.javaR1-R22](diffhunk://#diff-b753fa0a018420b56a27f912013a15923fbc5a540228a521a0739b1ab16ed333R1-R22))
* Added a handler for `GeneralException` in `GlobalExceptionHandler` to return structured error responses. (`GlobalExceptionHandler.java` - [src/main/java/com/gtu/auth_service/presentation/exception/GlobalExceptionHandler.javaR89-R98](diffhunk://#diff-5be6c496c62f2d0df6234c2565ac9dba0251f99699552447e537a3c530ecf131R89-R98))

### DTO enhancements:
* Added `ResetPasswordDTO` and `ResetPasswordRequestDTO` classes to encapsulate request data for password reset operations. (`ResetPasswordDTO.java` - [[1]](diffhunk://#diff-3afc01382fcaa1180e941e33a077d4a37acca5c9fc314ada48a46cdeee0fb8fcR1-R13) `ResetPasswordRequestDTO.java` - [[2]](diffhunk://#diff-0c30c97312a2aebb1aacfb51a89a9b40724441f35749fffcacf6fb74a1ce0b4bR1-R12)
* Updated `AuthController` to use the new DTOs for handling password reset requests and responses. (`AuthController.java` - [src/main/java/com/gtu/auth_service/presentation/rest/AuthController.javaL36-R49](diffhunk://#diff-793ff70aa31751f5be2080f5d90777c07a87ad440950b28e77aedded24b2a7d6L36-R49))

### Test updates:
* Refactored `ResetPasswordServiceImplTest` to align with the consolidated reset link configuration and updated the test setup accordingly. (`ResetPasswordServiceImplTest.java` - [src/test/java/com/gtu/auth_service/application/service/ResetPasswordServiceImplTest.javaL60-R64](diffhunk://#diff-b99475560ddfd00326adc2694227b493546b658d3b3f66a43eddf538b1ff2014L60-R64))

### Minor adjustments:
* Fixed a bug in `AuthServiceImpl` by correctly setting the `id` field when registering a passenger. (`AuthServiceImpl.java` - [src/main/java/com/gtu/auth_service/application/service/AuthServiceImpl.javaL85-R85](diffhunk://#diff-82c59c019487c6c37f79fa1ca975c93ab5751b32afd405f1045c8ba4f458f07dL85-R85))